### PR TITLE
feat: macOS theme and toolbar redesign

### DIFF
--- a/src/MinMe.Avalonia/App.axaml
+++ b/src/MinMe.Avalonia/App.axaml
@@ -3,6 +3,7 @@
              x:Class="MinMe.Avalonia.App"
              xmlns:local="clr-namespace:MinMe.Avalonia"
              xmlns:converter="clr-namespace:MinMe.Avalonia.Views.Converters;assembly=MinMe.Avalonia"
+             xmlns:macOS="using:Devolutions.AvaloniaTheme.MacOS"
              RequestedThemeVariant="Default">
     
     <Application.DataTemplates>
@@ -14,7 +15,6 @@
     </Application.Resources>
     
     <Application.Styles>
-        <FluentTheme />
-        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
+        <macOS:DevolutionsMacOsTheme />
     </Application.Styles>
 </Application>

--- a/src/MinMe.Avalonia/App.axaml
+++ b/src/MinMe.Avalonia/App.axaml
@@ -16,6 +16,5 @@
     
     <Application.Styles>
         <macOS:DevolutionsMacOsTheme />
-        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
     </Application.Styles>
 </Application>

--- a/src/MinMe.Avalonia/App.axaml
+++ b/src/MinMe.Avalonia/App.axaml
@@ -16,5 +16,6 @@
     
     <Application.Styles>
         <macOS:DevolutionsMacOsTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
     </Application.Styles>
 </Application>

--- a/src/MinMe.Avalonia/MinMe.Avalonia.csproj
+++ b/src/MinMe.Avalonia/MinMe.Avalonia.csproj
@@ -45,6 +45,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
     <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.2.20" />
     <PackageReference Include="Clippit" Version="3.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />

--- a/src/MinMe.Avalonia/MinMe.Avalonia.csproj
+++ b/src/MinMe.Avalonia/MinMe.Avalonia.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.12" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.9" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
     <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.2.20" />
     <PackageReference Include="Clippit" Version="3.2.0" />

--- a/src/MinMe.Avalonia/MinMe.Avalonia.csproj
+++ b/src/MinMe.Avalonia/MinMe.Avalonia.csproj
@@ -40,19 +40,13 @@
     <ProjectReference Include="..\MinMe\MinMe.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.10" />
+    <PackageReference Include="Avalonia" Version="11.3.12" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference
-      Condition="'$(Configuration)' == 'Debug'"
-      Include="Avalonia.Diagnostics"
-      Version="11.3.10"
-    />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.10" />
-    <PackageReference Include="Clippit" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.2.20" />
+    <PackageReference Include="Clippit" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/MinMe.Avalonia/MinMe.Avalonia.csproj
+++ b/src/MinMe.Avalonia/MinMe.Avalonia.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.8" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.12" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.12" />
     <PackageReference Include="Devolutions.AvaloniaTheme.MacOS" Version="2026.2.20" />
     <PackageReference Include="Clippit" Version="3.2.0" />

--- a/src/MinMe.Avalonia/Program.cs
+++ b/src/MinMe.Avalonia/Program.cs
@@ -17,7 +17,6 @@ class Program
         AppBuilder
             .Configure<App>()
             .UsePlatformDetect()
-            .WithInterFont()
             .LogToTrace()
             .UseReactiveUI();
 }

--- a/src/MinMe.Avalonia/ViewModels/ActionsPanelViewModel.cs
+++ b/src/MinMe.Avalonia/ViewModels/ActionsPanelViewModel.cs
@@ -53,7 +53,6 @@ class ActionsPanelViewModel : ViewModelBase
         {
             new(
                 "2160p (4K)",
-                "4K",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(3840, 2160),
@@ -62,7 +61,6 @@ class ActionsPanelViewModel : ViewModelBase
             ),
             new(
                 "1080p (Full HD)",
-                "1080p",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(1920, 1080),
@@ -71,7 +69,6 @@ class ActionsPanelViewModel : ViewModelBase
             ),
             new(
                 "720p (HD ready)",
-                "720p",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(1280, 720),
@@ -82,10 +79,9 @@ class ActionsPanelViewModel : ViewModelBase
         _selectedMode = PublishModes[1];
     }
 
-    public class PublishMode(string name, string shortName, ImageOptimizerOptions options)
+    public class PublishMode(string name, ImageOptimizerOptions options)
     {
         public string Name { get; } = name;
-        public string ShortName { get; } = shortName;
         public ImageOptimizerOptions Options { get; } = options;
 
         public override string ToString() => Name;

--- a/src/MinMe.Avalonia/ViewModels/ActionsPanelViewModel.cs
+++ b/src/MinMe.Avalonia/ViewModels/ActionsPanelViewModel.cs
@@ -53,6 +53,7 @@ class ActionsPanelViewModel : ViewModelBase
         {
             new(
                 "2160p (4K)",
+                "4K",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(3840, 2160),
@@ -61,6 +62,7 @@ class ActionsPanelViewModel : ViewModelBase
             ),
             new(
                 "1080p (Full HD)",
+                "1080p",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(1920, 1080),
@@ -69,6 +71,7 @@ class ActionsPanelViewModel : ViewModelBase
             ),
             new(
                 "720p (HD ready)",
+                "720p",
                 new ImageOptimizerOptions
                 {
                     ExpectedScreenSize = new Size(1280, 720),
@@ -79,9 +82,10 @@ class ActionsPanelViewModel : ViewModelBase
         _selectedMode = PublishModes[1];
     }
 
-    public class PublishMode(string name, ImageOptimizerOptions options)
+    public class PublishMode(string name, string shortName, ImageOptimizerOptions options)
     {
         public string Name { get; } = name;
+        public string ShortName { get; } = shortName;
         public ImageOptimizerOptions Options { get; } = options;
 
         public override string ToString() => Name;
@@ -202,6 +206,7 @@ class ActionsPanelViewModel : ViewModelBase
         if (file is null)
             return;
 
+        var mode = SelectedMode;
         var targetFilePath = file.TryGetLocalPath()!;
         await _stateService.RunTask(async () =>
         {
@@ -216,7 +221,7 @@ class ActionsPanelViewModel : ViewModelBase
                 extension,
                 originalStream,
                 out _,
-                SelectedMode.Options
+                mode.Options
             );
 
             await using var targetFile = File.Create(targetFilePath);

--- a/src/MinMe.Avalonia/Views/ActionsPanelView.axaml
+++ b/src/MinMe.Avalonia/Views/ActionsPanelView.axaml
@@ -16,7 +16,8 @@
     </Style>
   </UserControl.Styles>
   <Border BorderBrush="{DynamicResource LayoutBorderMidBrush}"
-          BorderThickness="0,0,0,1">
+          BorderThickness="0,0,0,1"
+          Padding="{Binding $parent[Window].WindowDecorationMargin}">
     <StackPanel Orientation="Horizontal">
       <Menu Classes="MacOS_Theme_MenuLabelBelowIcon Toolbar">
         <MenuItem Header="Open" Command="{Binding OpenCommand}">

--- a/src/MinMe.Avalonia/Views/ActionsPanelView.axaml
+++ b/src/MinMe.Avalonia/Views/ActionsPanelView.axaml
@@ -1,27 +1,58 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="50"
              x:Class="MinMe.Avalonia.Views.ActionsPanelView">
   <UserControl.Styles>
-    <Style Selector="Button">
-        <Setter Property="Padding" Value="5"/>
-        <Setter Property="Margin" Value="2"/>
+    <Style Selector="Menu.Toolbar > MenuItem ContentControl#PART_IconPresenter">
+      <Setter Property="MaxWidth" Value="28" />
+      <Setter Property="MaxHeight" Value="28" />
+    </Style>
+    <Style Selector="Menu.Toolbar > MenuItem ContentPresenter#PART_HeaderPresenter.TopLevelMenuItem">
+      <Setter Property="MinWidth" Value="55" />
+      <Setter Property="MaxWidth" Value="80" />
+      <Setter Property="FontSize" Value="13" />
     </Style>
   </UserControl.Styles>
-  <StackPanel Orientation="Horizontal">
-    <Button DockPanel.Dock="Left" Command="{Binding OpenCommand}">Open File</Button>
-    <Separator Width="20"></Separator>
-    <Button Command="{Binding PublishCommand}">Publish Slides</Button>
-    <Separator Width="20"></Separator>
-    <Border BorderThickness="1">
-      <Grid ColumnDefinitions="Auto,5,130" RowDefinitions="*,*">
-        <Button Grid.RowSpan="2" Command="{Binding OptimizeCommand}">Optimize</Button>
-        <TextBlock Grid.Row="0" Grid.Column="2" VerticalAlignment="Center">Target screen resolution</TextBlock>
-        <ComboBox Grid.Column="2" Grid.Row="1" ItemsSource="{Binding PublishModes}"
-                  SelectedItem="{Binding SelectedMode, Mode=TwoWay}" />
-      </Grid>
-    </Border>
-  </StackPanel>
+  <Border BorderBrush="{DynamicResource LayoutBorderMidBrush}"
+          BorderThickness="0,0,0,1">
+    <StackPanel Orientation="Horizontal">
+      <Menu Classes="MacOS_Theme_MenuLabelBelowIcon Toolbar">
+        <MenuItem Header="Open" Command="{Binding OpenCommand}">
+          <MenuItem.Icon>
+            <PathIcon Data="M1.5 3.5C1.5 2.39543 2.39543 1.5 3.5 1.5H6.29289C6.82333 1.5 7.33204 1.71071 7.70711 2.08579L8.91421 3.29289C9.10175 3.48043 9.35811 3.58579 9.62541 3.58579H12.5C13.6046 3.58579 14.5 4.48122 14.5 5.58579V12.5C14.5 13.6046 13.6046 14.5 12.5 14.5H3.5C2.39543 14.5 1.5 13.6046 1.5 12.5V3.5Z"
+                     Width="26" Height="26" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="Publish" Command="{Binding PublishCommand}">
+          <MenuItem.Icon>
+            <PathIcon Data="M3 2C3 1.44772 3.44772 1 4 1H9L13 5V14C13 14.5523 12.5523 15 12 15H4C3.44772 15 3 14.5523 3 14V2ZM9 1V5H13M7 9H12M12 9L10 7M12 9L10 11"
+                     Width="26" Height="26" />
+          </MenuItem.Icon>
+        </MenuItem>
+        <MenuItem Header="-" />
+      </Menu>
+      <StackPanel Orientation="Vertical"
+                  VerticalAlignment="Center"
+                  Margin="0,0,0,0">
+        <TextBlock Text="Resolution"
+                   FontSize="13"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,2" />
+        <ComboBox ItemsSource="{Binding PublishModes}"
+                  SelectedItem="{Binding SelectedMode}"
+                  MinWidth="80"
+                  FontSize="13" />
+      </StackPanel>
+      <Menu Classes="MacOS_Theme_MenuLabelBelowIcon Toolbar">
+        <MenuItem Header="Optimize" Command="{Binding OptimizeCommand}">
+          <MenuItem.Icon>
+            <PathIcon Data="M8 1C8.55228 1 9 1.44772 9 2V3.07089C9.64428 3.18289 10.249 3.40193 10.7942 3.71121L11.5523 2.95312C11.9428 2.5626 12.576 2.5626 12.9665 2.95312L13.0469 3.03353C13.4374 3.42405 13.4374 4.05722 13.0469 4.44774L12.2888 5.20583C12.5981 5.75101 12.8171 6.35572 12.9291 7H14C14.5523 7 15 7.44772 15 8C15 8.55228 14.5523 9 14 9H12.9291C12.8171 9.64428 12.5981 10.249 12.2888 10.7942L13.0469 11.5523C13.4374 11.9428 13.4374 12.576 13.0469 12.9665L12.9665 13.0469C12.576 13.4374 11.9428 13.4374 11.5523 13.0469L10.7942 12.2888C10.249 12.5981 9.64428 12.8171 9 12.9291V14C9 14.5523 8.55228 15 8 15C7.44772 15 7 14.5523 7 14V12.9291C6.35572 12.8171 5.75101 12.5981 5.20583 12.2888L4.44774 13.0469C4.05722 13.4374 3.42405 13.4374 3.03353 13.0469L2.95312 12.9665C2.5626 12.576 2.5626 11.9428 2.95312 11.5523L3.71121 10.7942C3.40193 10.249 3.18289 9.64428 3.07089 9H2C1.44772 9 1 8.55228 1 8C1 7.44772 1.44772 7 2 7H3.07089C3.18289 6.35572 3.40193 5.75101 3.71121 5.20583L2.95312 4.44774C2.5626 4.05722 2.5626 3.42405 2.95312 3.03353L3.03353 2.95312C3.42405 2.5626 4.05722 2.5626 4.44774 2.95312L5.20583 3.71121C5.75101 3.40193 6.35572 3.18289 7 3.07089V2C7 1.44772 7.44772 1 8 1ZM8 10.5C9.38071 10.5 10.5 9.38071 10.5 8C10.5 6.61929 9.38071 5.5 8 5.5C6.61929 5.5 5.5 6.61929 5.5 8C5.5 9.38071 6.61929 10.5 8 10.5Z"
+                     Width="26" Height="26" />
+          </MenuItem.Icon>
+        </MenuItem>
+      </Menu>
+    </StackPanel>
+  </Border>
 </UserControl>

--- a/src/MinMe.Avalonia/Views/MainView.axaml
+++ b/src/MinMe.Avalonia/Views/MainView.axaml
@@ -5,62 +5,16 @@
              xmlns:view="clr-namespace:MinMe.Avalonia.Views"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="MinMe.Avalonia.Views.MainView">
-    <UserControl.Styles>
-      <Style Selector="TabControl">
-        <Setter Property="Background" Value="#F0F0F0"/>
-      </Style>
-      <Style Selector="TabControl WrapPanel">
-        <Setter Property="Background" Value="#2B579A"/>
-      </Style>
-
-      <Style Selector="TabItem">
-        <Setter Property="FontSize" Value="14"/>
-        <Setter Property="Height" Value="34"/>
-        <!--<Setter Property="VerticalAlignment" Value="Center"/>-->
-        <Setter Property="VerticalContentAlignment" Value="Center" />
-        <Setter Property="Background" Value="#2B579A"/>
-        <Setter Property="Foreground" Value="#F0F0F0"/>
-        <Setter Property="Margin" Value="0 0 0 0"/>
-        <Setter Property="Padding" Value="10 0"/>
-      </Style>
-      <Style Selector="TabItem:pointerover /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="#124078"/>
-      </Style>
-
-      <Style Selector="TabItem:focus">
-        <Setter Property="Foreground" Value="#2B579A"/>
-        <Setter Property="Margin" Value="0 0 0 0"/>
-        <Setter Property="Padding" Value="10 0"/>
-      </Style>
-      <Style Selector="TabItem:focus /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="#f0f0f0"/>
-      </Style>
-
-      <Style Selector="TabItem:selected">
-        <Setter Property="Foreground" Value="#2B579A"/>
-        <Setter Property="Margin" Value="0 0 0 0"/>
-        <Setter Property="Padding" Value="10 0"/>
-      </Style>
-      <Style Selector="TabItem:selected /template/ ContentPresenter#PART_ContentPresenter">
-        <Setter Property="Background" Value="#f0f0f0"/>
-      </Style>
-    </UserControl.Styles>
-    <Grid RowDefinitions="50,*,Auto" IsEnabled="{Binding !IsBusy}">
+    <Grid RowDefinitions="Auto,*,Auto" IsEnabled="{Binding !IsBusy}">
       <view:ActionsPanelView DataContext="{Binding ActionsPanelViewModel}"></view:ActionsPanelView>
       <TabControl Grid.Row="1" Margin="0,2,0,0">
         <TabItem Header="Overview">
           <view:OverviewView DataContext="{Binding OverviewViewModel}" />
         </TabItem>
-        <TabItem>
-          <TabItem.Header>
-            <TextBlock Text="{Binding FileContentInfo.Slides.Count, StringFormat=Slides ({0:D})}"></TextBlock>
-          </TabItem.Header>
+        <TabItem Header="{Binding FileContentInfo.Slides.Count, StringFormat='Slides ({0:D})', FallbackValue='Slides'}">
           <view:SlidesInfoView DataContext="{Binding SlidesInfoViewModel}" />
         </TabItem>
-        <TabItem>
-          <TabItem.Header>
-            <TextBlock Text="{Binding FileContentInfo.Parts.Count, StringFormat=Parts ({0:D})}"></TextBlock>
-          </TabItem.Header>
+        <TabItem Header="{Binding FileContentInfo.Parts.Count, StringFormat='Parts ({0:D})', FallbackValue='Parts'}">
           <view:PartsInfoView DataContext="{Binding PartsInfoViewModel}" />
         </TabItem>
       </TabControl>

--- a/src/MinMe.Avalonia/Views/MainWindow.axaml
+++ b/src/MinMe.Avalonia/Views/MainWindow.axaml
@@ -9,5 +9,7 @@
         x:Class="MinMe.Avalonia.Views.MainWindow"
         Icon="/Assets/minme-logo.ico"
         Title="MinMe"
+        ExtendClientAreaToDecorationsHint="True"
+        ExtendClientAreaChromeHints="PreferSystemChrome"
         Content="{Binding Content}">
 </Window>

--- a/src/MinMe/MinMe.csproj
+++ b/src/MinMe/MinMe.csproj
@@ -18,7 +18,7 @@
     <None Include="..\MinMe.Avalonia\Assets\AppIcon-512@2x.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DocumentFormat.OpenXml" Version="3.3.0" />
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.4.1" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
   </ItemGroup>

--- a/tests/MinMe.Tests/MinMe.Tests.csproj
+++ b/tests/MinMe.Tests/MinMe.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectReference Include="..\..\src\MinMe\MinMe.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Replace `Avalonia.Themes.Fluent` with `Devolutions.AvaloniaTheme.MacOS` for native macOS-style appearance on all platforms
- Redesign toolbar with HandBrake-inspired icon-above-label layout using `MacOS_Theme_MenuLabelBelowIcon` menu class
- Add resolution ComboBox with label placed between separator and Optimize button for quick mode selection
- Extend client area into title bar for integrated chrome (`ExtendClientAreaToDecorationsHint`)
- Fix tab headers to use direct `Header` binding with `FallbackValue` instead of nested `TextBlock`
- Remove inline Office-blue styles from `MainView.axaml`, letting the macOS theme handle all styling
- Update NuGet dependencies (Avalonia 11.3.12, DocumentFormat.OpenXml 3.4.1, Clippit 3.2.0, test packages)